### PR TITLE
minor changes for optional blocks

### DIFF
--- a/cgen/templates/cpp-xmlwrp/config.hpp.j2
+++ b/cgen/templates/cpp-xmlwrp/config.hpp.j2
@@ -14,6 +14,14 @@
 {%- endif -%}
 {%- endmacro -%}
 
+{%- macro insert_optional_struct(member) -%}
+{%- if options['cpp'] and options['cpp']['use_optional'] | default(false) and not member.required -%}
+std::optional<{{ m.type_case(member.type.name) }}> {{ m.value_case(member.name) }}
+{%- else -%}
+{{ m.type_case(member.type.name) }} {{ m.value_case(member.name) }}
+{%- endif -%}
+{%- endmacro -%}
+
 {%- macro insert_optional_vector(member) -%}
 {#-{%- if not member.required and not member.default %}std::optional<{% endif -%}-#}
 std::vector<{{ m.type_name(member.type.item_type.name) }}>
@@ -111,7 +119,7 @@ struct {{ m.type_case(type.name) }}
 {%- if not member.type.name in unique_types -%}
 {{ insert_struct(member) }}
 {%- endif %}
-struct {{ m.type_case(member.type.name) }} {{ m.value_case(member.name) }};
+{{ insert_optional_struct(member) }};
 {%- elif member.type.type == 'array' or member.type.type == 'list' %}
 {{ insert_optional_vector(member) }} {{ m.value_case(member.name) }};
 {%- elif member.type.type == 'enum' %}

--- a/cgen/templates/cpp-xmlwrp/enums.hpp
+++ b/cgen/templates/cpp-xmlwrp/enums.hpp
@@ -65,9 +65,9 @@ template<typename T> constexpr size_t enum_size() { return 0; }
     }}}                                                                        \
     enum class NAME { ___ENUM_VALUES(VALUES) };                                \
     inline const char* to_string(NAME e) {                                     \
-        return enums::details::NAME::strings[static_cast<int>(e)]; }           \
+        return enums::details::NAME::strings[static_cast<size_t>(e)]; }        \
     inline bool from_string(const char* s, NAME& e) {                          \
-        for (auto n = 0; n < enums::details::NAME::enum_size; n++) {           \
+        for (size_t n = 0; n < enums::details::NAME::enum_size; n++) {         \
             if (strcmp(s, enums::details::NAME::strings[n]) == 0) {            \
                 e = static_cast<NAME>(n); return true; } }                     \
         e = static_cast<NAME>(enums::details::NAME::enum_size-1);              \

--- a/cgen/templates/doc-html/doc.html.j2
+++ b/cgen/templates/doc-html/doc.html.j2
@@ -3,14 +3,21 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <title>Bootstrap demo</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
   </head>
   <body>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-Zenh87qX5JnK2Jl0vWa8Ck2rdkQ2Bzep5IDxbcnCeuOxjzrPF/et3URy9Bv1WTRi" crossorigin="anonymous">
     {% for k,v in docs.sections.items() %}
     <br>
     <h3>{{ k|capitalize }}</h3>
     <table class="table table-hover">
+      <col style="width: 5%;">
+      <col style="width: 30%;">
+      <col style="width: 40%;">
+      <col style="width: 10%;">
+      <col style="width: 15%;">
       <thead>
         <tr>
           <th scope="col">#</th>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "cgen"
-version = "0.2.0"
+version = "0.2.1"
 requires-python = ">=3.8"
 authors = [
     { name = "ngruenwald", email = "some@mail.com" }


### PR DESCRIPTION
feat: std::optional for structs (whole sections which are not required)
without this leaving out a whole section is kind of UB?

fix: cpp warnings regarding size_t
fix: html doc tables